### PR TITLE
Initiating Game Between Matched Users

### DIFF
--- a/accounts/management/commands/notify_matches.py
+++ b/accounts/management/commands/notify_matches.py
@@ -48,7 +48,10 @@ class Command(BaseCommand):
                     match.notification_sent = True
                     match.save()
 
-                    success_message = f"Notification sent for match between {match.user1.username} and {match.user2.username}."
+                    success_message = (
+                        f"Notification sent for match between {match.user1.username} "
+                        f"and {match.user2.username}."
+                    )
                     self.stdout.write(self.style.SUCCESS(success_message))
 
                 except Exception as e:

--- a/accounts/management/commands/notify_matches.py
+++ b/accounts/management/commands/notify_matches.py
@@ -1,14 +1,16 @@
 from django.core.management.base import BaseCommand
 from django.utils import timezone
 from datetime import timedelta
-from accounts.models import Match
 from django.core.mail import send_mail
 from django.conf import settings
+from django.urls import reverse
 import logging
+
+from accounts.models import Match
+from game.models import GameSession, Player
 
 # Configure a logger for the command
 logger = logging.getLogger(__name__)
-
 
 class Command(BaseCommand):
     help = "Sends notifications to users about new matches at midnight."
@@ -21,15 +23,36 @@ class Command(BaseCommand):
 
         for match in new_matches:
             try:
+                # Create a game session for the match
+                game_session, created = GameSession.objects.get_or_create(
+                    playerA__user=match.user1,
+                    playerB__user=match.user2,
+                    defaults={
+                        'playerA': Player.objects.get_or_create(user=match.user1)[0],
+                        'playerB': Player.objects.get_or_create(user=match.user2)[0],
+                        'is_active': True,  # Assuming you want to start the session as active
+                    }
+                )
+                
+                # Ensure the game session is initialized properly
+                if created and not game_session.current_game_turn_id:
+                    game_session.initialize_game()
+
+                # Generate the URL for the game session
+                game_session_url = self.get_full_url_with_domain(game_session.get_absolute_url())
+
+                # Email messages including the game session link
                 user1_msg = (
                     f"Hello {match.user1.username},\n\n"
                     "You have been matched with someone on our platform. "
                     "Please log in to see more details about your match."
+                    f"\n\nClick here to join the game: {game_session_url}"
                 )
                 user2_msg = (
                     f"Hello {match.user2.username},\n\n"
                     "You have been matched with someone on our platform. "
                     "Please log in to see more details about your match."
+                    f"\n\nClick here to join the game: {game_session_url}"
                 )
 
                 # Send notification to user1
@@ -55,7 +78,8 @@ class Command(BaseCommand):
 
                 success_message = (
                     f"Notification sent for match between "
-                    f"{match.user1.username} and {match.user2.username}"
+                    f"{match.user1.username} and {match.user2.username}. "
+                    f"Game session link included: {game_session_url}"
                 )
                 self.stdout.write(self.style.SUCCESS(success_message))
 
@@ -66,3 +90,11 @@ class Command(BaseCommand):
                 )
                 logger.error(error_message)
                 self.stderr.write(self.style.ERROR(error_message))
+    
+    def get_full_url_with_domain(self, relative_url):
+        # Ensure that SITE_URL ends with a slash
+        site_url = settings.SITE_URL if settings.SITE_URL.endswith('/') else settings.SITE_URL + '/'
+        return f"{site_url}{relative_url.lstrip('/')}"
+
+# In your settings.py, make sure to define the SITE_URL like so:
+# SITE_URL = 'http://roleplaydate-dev3.us-east-1.elasticbeanstalk.com/'

--- a/accounts/management/commands/notify_matches.py
+++ b/accounts/management/commands/notify_matches.py
@@ -12,6 +12,7 @@ from game.models import GameSession, Player
 # Configure a logger for the command
 logger = logging.getLogger(__name__)
 
+
 class Command(BaseCommand):
     help = "Sends notifications to users about new matches at midnight."
 
@@ -30,8 +31,12 @@ class Command(BaseCommand):
                     game_session.save()
 
                     # Get or create the Player instances, associating them with the new GameSession
-                    playerA, _ = Player.objects.get_or_create(user=match.user1, defaults={'game_session': game_session})
-                    playerB, _ = Player.objects.get_or_create(user=match.user2, defaults={'game_session': game_session})
+                    playerA, _ = Player.objects.get_or_create(
+                        user=match.user1, defaults={"game_session": game_session}
+                    )
+                    playerB, _ = Player.objects.get_or_create(
+                        user=match.user2, defaults={"game_session": game_session}
+                    )
 
                     # Link the GameSession with the Players
                     game_session.playerA = playerA
@@ -43,8 +48,8 @@ class Command(BaseCommand):
                         game_session.initialize_game()
 
                 # Send email notifications
-                self.send_email(match.user1, 'You have a new match!')
-                self.send_email(match.user2, 'You have a new match!')
+                self.send_email(match.user1, "You have a new match!")
+                self.send_email(match.user2, "You have a new match!")
 
                 # Mark the match as notified
                 match.notification_sent = True
@@ -77,4 +82,3 @@ class Command(BaseCommand):
             recipient_list=[user.email],
             fail_silently=False,
         )
-    

--- a/accounts/management/commands/notify_matches.py
+++ b/accounts/management/commands/notify_matches.py
@@ -74,5 +74,8 @@ class Command(BaseCommand):
         )
     
     def get_full_url_with_domain(self, relative_url):
-        site_url = settings.SITE_URL.rstrip('/') + '/'
-        return f"{site_url}{relative_url}"
+        site_url = settings.SITE_URL
+        if not site_url.endswith('/'):
+            site_url += '/'
+        return f"{site_url}{relative_url.lstrip('/')}"
+

--- a/accounts/management/commands/notify_matches.py
+++ b/accounts/management/commands/notify_matches.py
@@ -42,18 +42,15 @@ class Command(BaseCommand):
                     if not game_session.current_game_turn_id:
                         game_session.initialize_game()
 
-                    # Generate the URL for the game session
-                    game_session_url = self.get_full_url_with_domain(game_session.get_absolute_url())
-
                 # Send email notifications
-                self.send_email(match.user1, game_session_url, 'You have a new match!')
-                self.send_email(match.user2, game_session_url, 'You have a new match!')
+                self.send_email(match.user1, 'You have a new match!')
+                self.send_email(match.user2, 'You have a new match!')
 
                 # Mark the match as notified
                 match.notification_sent = True
                 match.save()
 
-                success_message = f"Notification sent for match between {match.user1.username} and {match.user2.username}. Game session link included: {game_session_url}"
+                success_message = f"Notification sent for match between {match.user1.username} and {match.user2.username}."
                 self.stdout.write(self.style.SUCCESS(success_message))
 
             except Exception as e:
@@ -62,7 +59,7 @@ class Command(BaseCommand):
                 self.stderr.write(self.style.ERROR(error_message))
 
     def send_email(self, user, url, subject):
-        message = f"Hello {user.username},\n\nYou have been matched with someone on our platform. Please log in to see more details about your match.\n\nClick here to join the game: {url}"
+        message = f"Hello {user.username},\n\nYou have been matched with someone on our platform. Please log in to see more details about your match."
         send_mail(
             subject=subject,
             message=message,
@@ -71,7 +68,5 @@ class Command(BaseCommand):
             fail_silently=False,
         )
     
-    def get_full_url_with_domain(self, relative_url):
-        site_url = settings.SITE_URL.rstrip('/') + '/'
-        return f"{site_url}{relative_url.lstrip('/')}"
+
 

--- a/accounts/management/commands/notify_matches.py
+++ b/accounts/management/commands/notify_matches.py
@@ -5,7 +5,6 @@ from django.core.mail import send_mail
 from django.conf import settings
 from django.db import transaction
 import logging
-from django.urls import reverse
 from accounts.models import Match
 from game.models import GameSession, Player
 
@@ -30,7 +29,8 @@ class Command(BaseCommand):
                     game_session = GameSession(is_active=True)
                     game_session.save()
 
-                    # Get or create the Player instances, associating them with the new GameSession
+                    # Get or create the Player instances,
+                    # associating them with the new GameSession
                     playerA, _ = Player.objects.get_or_create(
                         user=match.user1, defaults={"game_session": game_session}
                     )
@@ -73,9 +73,9 @@ class Command(BaseCommand):
         message = (
             f"Hello {user.username},\n\n"
             "Exciting news! You've been matched in 'Roleplay and then Date'. "
-            "This isn't just another swipe-and-match encounter. Prepare yourself for an "
-            "immersive journey of anonymous role-playing, and a unique 28-day narrative "
-            "that lets you connect with your match on a deeper level.\n\n"
+            "This isn't just another swipe-and-match encounter. Prepare yourself for "
+            "an immersive journey of anonymous role-playing, and a unique 28-day "
+            "narrative that lets you connect with your match on a deeper level.\n\n"
             "Log in to the app and play the game with your companion in this adventure "
             "of moonlit tales and mysterious connections. "
             "Once inside, you can embark on your journey together and see where the "

--- a/accounts/management/commands/notify_matches.py
+++ b/accounts/management/commands/notify_matches.py
@@ -12,6 +12,7 @@ from game.models import GameSession, Player
 # Configure a logger for the command
 logger = logging.getLogger(__name__)
 
+
 class Command(BaseCommand):
     help = "Sends notifications to users about new matches at midnight."
 

--- a/accounts/management/commands/notify_matches.py
+++ b/accounts/management/commands/notify_matches.py
@@ -59,7 +59,17 @@ class Command(BaseCommand):
                 self.stderr.write(self.style.ERROR(error_message))
 
     def send_email(self, user, subject):
-        message = f"Hello {user.username},\n\nYou have been matched with someone on our platform. Please log in to see more details about your match."
+        message = (
+            f"Hello {user.username},\n\n"
+            "Exciting news! You've been matched in 'Roleplay and then Date'. "
+            "This isn't just another swipe-and-match encounter. Prepare yourself for an immersive journey of "
+            "anonymous role-playing, and a unique 28-day narrative that lets you connect with your match on a deeper level.\n\n"
+            "Log in to the app and play the game with your companion in this adventure of moonlit tales and mysterious connections. "
+            "Once inside, you can embark on your journey together and see where the story takes you.\n\n"
+            "Your moonlit adventure awaits!\n\n"
+            "Best wishes,\n"
+            "The Roleplay and then Date Team"
+        )
         send_mail(
             subject=subject,
             message=message,
@@ -68,5 +78,3 @@ class Command(BaseCommand):
             fail_silently=False,
         )
     
-
-

--- a/accounts/management/commands/notify_matches.py
+++ b/accounts/management/commands/notify_matches.py
@@ -58,7 +58,7 @@ class Command(BaseCommand):
                 logger.error(error_message)
                 self.stderr.write(self.style.ERROR(error_message))
 
-    def send_email(self, user, url, subject):
+    def send_email(self, user, subject):
         message = f"Hello {user.username},\n\nYou have been matched with someone on our platform. Please log in to see more details about your match."
         send_mail(
             subject=subject,

--- a/accounts/management/commands/notify_matches.py
+++ b/accounts/management/commands/notify_matches.py
@@ -1,16 +1,14 @@
 from django.core.management.base import BaseCommand
 from django.utils import timezone
 from datetime import timedelta
+from accounts.models import Match
 from django.core.mail import send_mail
 from django.conf import settings
-from django.urls import reverse
 import logging
-
-from accounts.models import Match
-from game.models import GameSession, Player
 
 # Configure a logger for the command
 logger = logging.getLogger(__name__)
+
 
 class Command(BaseCommand):
     help = "Sends notifications to users about new matches at midnight."
@@ -23,36 +21,15 @@ class Command(BaseCommand):
 
         for match in new_matches:
             try:
-                # Create a game session for the match
-                game_session, created = GameSession.objects.get_or_create(
-                    playerA__user=match.user1,
-                    playerB__user=match.user2,
-                    defaults={
-                        'playerA': Player.objects.get_or_create(user=match.user1)[0],
-                        'playerB': Player.objects.get_or_create(user=match.user2)[0],
-                        'is_active': True,  # Assuming you want to start the session as active
-                    }
-                )
-                
-                # Ensure the game session is initialized properly
-                if created and not game_session.current_game_turn_id:
-                    game_session.initialize_game()
-
-                # Generate the URL for the game session
-                game_session_url = self.get_full_url_with_domain(game_session.get_absolute_url())
-
-                # Email messages including the game session link
                 user1_msg = (
                     f"Hello {match.user1.username},\n\n"
                     "You have been matched with someone on our platform. "
                     "Please log in to see more details about your match."
-                    f"\n\nClick here to join the game: {game_session_url}"
                 )
                 user2_msg = (
                     f"Hello {match.user2.username},\n\n"
                     "You have been matched with someone on our platform. "
                     "Please log in to see more details about your match."
-                    f"\n\nClick here to join the game: {game_session_url}"
                 )
 
                 # Send notification to user1
@@ -78,8 +55,7 @@ class Command(BaseCommand):
 
                 success_message = (
                     f"Notification sent for match between "
-                    f"{match.user1.username} and {match.user2.username}. "
-                    f"Game session link included: {game_session_url}"
+                    f"{match.user1.username} and {match.user2.username}"
                 )
                 self.stdout.write(self.style.SUCCESS(success_message))
 
@@ -90,11 +66,3 @@ class Command(BaseCommand):
                 )
                 logger.error(error_message)
                 self.stderr.write(self.style.ERROR(error_message))
-    
-    def get_full_url_with_domain(self, relative_url):
-        # Ensure that SITE_URL ends with a slash
-        site_url = settings.SITE_URL if settings.SITE_URL.endswith('/') else settings.SITE_URL + '/'
-        return f"{site_url}{relative_url.lstrip('/')}"
-
-# In your settings.py, make sure to define the SITE_URL like so:
-# SITE_URL = 'http://roleplaydate-dev3.us-east-1.elasticbeanstalk.com/'

--- a/accounts/management/commands/notify_matches.py
+++ b/accounts/management/commands/notify_matches.py
@@ -3,8 +3,9 @@ from django.utils import timezone
 from datetime import timedelta
 from django.core.mail import send_mail
 from django.conf import settings
-from django.urls import reverse
+from django.db import transaction
 import logging
+from django.urls import reverse
 
 from accounts.models import Match
 from game.models import GameSession, Player
@@ -17,84 +18,61 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         yesterday = timezone.now() - timedelta(days=1)
-        new_matches = Match.objects.filter(
-            matched_at__gte=yesterday, notification_sent=False
-        )
+        new_matches = Match.objects.filter(matched_at__gte=yesterday, notification_sent=False)
 
         for match in new_matches:
             try:
-                # Create a game session for the match
-                game_session, created = GameSession.objects.get_or_create(
-                    playerA__user=match.user1,
-                    playerB__user=match.user2,
-                    defaults={
-                        'playerA': Player.objects.get_or_create(user=match.user1)[0],
-                        'playerB': Player.objects.get_or_create(user=match.user2)[0],
-                        'is_active': True,  # Assuming you want to start the session as active
-                    }
-                )
-                
-                # Ensure the game session is initialized properly
-                if created and not game_session.current_game_turn_id:
+                with transaction.atomic():
+                    # Create a new GameSession instance
+                    game_session = GameSession()
+                    game_session.save()
+
+                    # Creating Player instances for each matched user
+                    player_A = Player.objects.create(user=match.user1, game_session=game_session)
+                    player_B = Player.objects.create(user=match.user2, game_session=game_session)
+
+                    # Assigning players to the game session
+                    game_session.playerA = player_A
+                    game_session.playerB = player_B
+                    game_session.save()
+
+                    # Initializing the game session
                     game_session.initialize_game()
 
-                # Generate the URL for the game session
-                game_session_url = self.get_full_url_with_domain(game_session.get_absolute_url())
+                    # Generate the URL for the game session
+                    game_session_url = self.get_full_url_with_domain(reverse('game:game_progress', kwargs={'game_id': game_session.game_id}))
 
-                # Email messages including the game session link
-                user1_msg = (
-                    f"Hello {match.user1.username},\n\n"
-                    "You have been matched with someone on our platform. "
-                    "Please log in to see more details about your match."
-                    f"\n\nClick here to join the game: {game_session_url}"
-                )
-                user2_msg = (
-                    f"Hello {match.user2.username},\n\n"
-                    "You have been matched with someone on our platform. "
-                    "Please log in to see more details about your match."
-                    f"\n\nClick here to join the game: {game_session_url}"
-                )
+                    # Send email notifications
+                    self.send_email(match.user1, game_session_url, 'You have a new match!')
+                    self.send_email(match.user2, game_session_url, 'You have a new match!')
 
-                # Send notification to user1
-                send_mail(
-                    subject="You have a new match!",
-                    message=user1_msg,
-                    from_email=settings.DEFAULT_FROM_EMAIL,
-                    recipient_list=[match.user1.email],
-                    fail_silently=False,
-                )
-                # Send notification to user2
-                send_mail(
-                    subject="You have a new match!",
-                    message=user2_msg,
-                    from_email=settings.DEFAULT_FROM_EMAIL,
-                    recipient_list=[match.user2.email],
-                    fail_silently=False,
-                )
+                    # Mark the match as notified
+                    match.notification_sent = True
+                    match.save()
 
-                # Mark the match as notified
-                match.notification_sent = True
-                match.save()
-
-                success_message = (
-                    f"Notification sent for match between "
-                    f"{match.user1.username} and {match.user2.username}. "
-                    f"Game session link included: {game_session_url}"
-                )
-                self.stdout.write(self.style.SUCCESS(success_message))
+                    success_message = (
+                        f"Notification sent for match between {match.user1.username} and {match.user2.username}. "
+                        f"Game session link included: {game_session_url}"
+                    )
+                    self.stdout.write(self.style.SUCCESS(success_message))
 
             except Exception as e:
                 error_message = (
-                    f"Failed to send notification for match between "
-                    f"{match.user1.username} and {match.user2.username}: {e}"
+                    f"Failed to send notification for match between {match.user1.username} and {match.user2.username}: {e}"
                 )
                 logger.error(error_message)
                 self.stderr.write(self.style.ERROR(error_message))
+
+    def send_email(self, user, url, subject):
+        message = f"Hello {user.username},\n\nYou have been matched with someone on our platform. Please log in to see more details about your match.\n\nClick here to join the game: {url}"
+        send_mail(
+            subject=subject,
+            message=message,
+            from_email=settings.DEFAULT_FROM_EMAIL,
+            recipient_list=[user.email],
+            fail_silently=False,
+        )
     
     def get_full_url_with_domain(self, relative_url):
-        # Ensure that SITE_URL ends with a slash
-        site_url = settings.SITE_URL if settings.SITE_URL.endswith('/') else settings.SITE_URL + '/'
-        return f"{site_url}{relative_url.lstrip('/')}"
-
-# In your settings.py, make sure to define the SITE_URL like so:
-# SITE_URL = 'http://roleplaydate-dev3.us-east-1.elasticbeanstalk.com/'
+        site_url = settings.SITE_URL.rstrip('/') + '/'
+        return f"{site_url}{relative_url}"

--- a/accounts/management/commands/notify_matches.py
+++ b/accounts/management/commands/notify_matches.py
@@ -50,10 +50,7 @@ class Command(BaseCommand):
                     match.notification_sent = True
                     match.save()
 
-                    success_message = (
-                        f"Notification sent for match between {match.user1.username} and {match.user2.username}. "
-                        f"Game session link included: {game_session_url}"
-                    )
+                    success_message = f"Notification sent for match between {match.user1.username} and {match.user2.username}."
                     self.stdout.write(self.style.SUCCESS(success_message))
 
             except Exception as e:
@@ -63,8 +60,18 @@ class Command(BaseCommand):
                 logger.error(error_message)
                 self.stderr.write(self.style.ERROR(error_message))
 
-    def send_email(self, user, url, subject):
-        message = f"Hello {user.username},\n\nYou have been matched with someone on our platform. Please log in to see more details about your match.\n\nClick here to join the game: {url}"
+    def send_email(self, user, subject):
+        message = (
+            f"Hello {user.username},\n\n"
+            "Exciting news! You've been matched in 'Roleplay and then Date'. "
+            "This isn't just another swipe-and-match encounter. Prepare yourself for an immersive journey of "
+            "anonymous role-playing, and a unique 28-day narrative that lets you connect with your match on a deeper level.\n\n"
+            "Log in to the app and play the game with your companion in this adventure of moonlit tales and mysterious connections. "
+            "Once inside, you can embark on your journey together and see where the story takes you.\n\n"
+            "Your moonlit adventure awaits!\n\n"
+            "Best wishes,\n"
+            "The Roleplay and then Date Team"
+        )
         send_mail(
             subject=subject,
             message=message,
@@ -72,10 +79,3 @@ class Command(BaseCommand):
             recipient_list=[user.email],
             fail_silently=False,
         )
-    
-    def get_full_url_with_domain(self, relative_url):
-        site_url = settings.SITE_URL
-        if not site_url.endswith('/'):
-            site_url += '/'
-        return f"{site_url}{relative_url.lstrip('/')}"
-

--- a/accounts/management/commands/notify_matches.py
+++ b/accounts/management/commands/notify_matches.py
@@ -11,12 +11,15 @@ from accounts.models import Match
 # Configure a logger for the command
 logger = logging.getLogger(__name__)
 
+
 class Command(BaseCommand):
     help = "Sends notifications to users about new matches at midnight."
 
     def handle(self, *args, **options):
         yesterday = timezone.now() - timedelta(days=1)
-        new_matches = Match.objects.filter(matched_at__gte=yesterday, notification_sent=False)
+        new_matches = Match.objects.filter(
+            matched_at__gte=yesterday, notification_sent=False
+        )
 
         for match in new_matches:
             try:
@@ -52,7 +55,6 @@ class Command(BaseCommand):
                     logger.error(f"Error sending email: {e}")
                     self.stderr.write(self.style.ERROR(f"Error sending email: {e}"))
                     raise CommandError(f"Error sending email: {e}")
-
 
             except CommandError as ce:
                 logger.error(str(ce))

--- a/accounts/management/commands/notify_matches.py
+++ b/accounts/management/commands/notify_matches.py
@@ -5,13 +5,12 @@ from django.core.mail import send_mail
 from django.conf import settings
 from django.db import transaction
 import logging
-
+from django.urls import reverse
 from accounts.models import Match
 from game.models import GameSession, Player
 
 # Configure a logger for the command
 logger = logging.getLogger(__name__)
-
 
 class Command(BaseCommand):
     help = "Sends notifications to users about new matches at midnight."
@@ -55,11 +54,17 @@ class Command(BaseCommand):
                 match.notification_sent = True
                 match.save()
 
-                success_message = f"Notification sent for match between {match.user1.username} and {match.user2.username}."
+                success_message = (
+                    f"Notification sent for match between "
+                    f"{match.user1.username} and {match.user2.username}."
+                )
                 self.stdout.write(self.style.SUCCESS(success_message))
 
             except Exception as e:
-                error_message = f"Failed to send notification for match between {match.user1.username} and {match.user2.username}: {e}"
+                error_message = (
+                    f"Failed to send notification for match between "
+                    f"{match.user1.username} and {match.user2.username}: {e}"
+                )
                 logger.error(error_message)
                 self.stderr.write(self.style.ERROR(error_message))
 
@@ -67,10 +72,13 @@ class Command(BaseCommand):
         message = (
             f"Hello {user.username},\n\n"
             "Exciting news! You've been matched in 'Roleplay and then Date'. "
-            "This isn't just another swipe-and-match encounter. Prepare yourself for an immersive journey of "
-            "anonymous role-playing, and a unique 28-day narrative that lets you connect with your match on a deeper level.\n\n"
-            "Log in to the app and play the game with your companion in this adventure of moonlit tales and mysterious connections. "
-            "Once inside, you can embark on your journey together and see where the story takes you.\n\n"
+            "This isn't just another swipe-and-match encounter. Prepare yourself for an "
+            "immersive journey of anonymous role-playing, and a unique 28-day narrative "
+            "that lets you connect with your match on a deeper level.\n\n"
+            "Log in to the app and play the game with your companion in this adventure "
+            "of moonlit tales and mysterious connections. "
+            "Once inside, you can embark on your journey together and see where the "
+            "story takes you.\n\n"
             "Your moonlit adventure awaits!\n\n"
             "Best wishes,\n"
             "The Roleplay and then Date Team"

--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -880,8 +880,12 @@ class NotifyMatchesCommandTest(TestCase):
     def setUpTestData(cls):
         # Set up data for the whole TestCase, which will be available in all test methods
         # Create two user instances for testing
-        cls.user1 = User.objects.create_user(username="user1", email="user1@example.com")
-        cls.user2 = User.objects.create_user(username="user2", email="user2@example.com")
+        cls.user1 = User.objects.create_user(
+            username="user1", email="user1@example.com"
+        )
+        cls.user2 = User.objects.create_user(
+            username="user2", email="user2@example.com"
+        )
 
         # Create a game session that is active and set up its current game turn
         cls.game_session = GameSession.objects.create(is_active=True)
@@ -890,15 +894,19 @@ class NotifyMatchesCommandTest(TestCase):
         cls.game_session.save()
 
         # Create player instances associated with the users and the game session
-        cls.player1 = Player.objects.create(user=cls.user1, game_session=cls.game_session, character_name="Character1")
-        cls.player2 = Player.objects.create(user=cls.user2, game_session=cls.game_session, character_name="Character2")
+        cls.player1 = Player.objects.create(
+            user=cls.user1, game_session=cls.game_session, character_name="Character1"
+        )
+        cls.player2 = Player.objects.create(
+            user=cls.user2, game_session=cls.game_session, character_name="Character2"
+        )
 
         # Create a match instance that simulates a match made yesterday without notification sent
         cls.match = Match.objects.create(
             user1=cls.user1,
             user2=cls.user2,
             matched_at=timezone.now() - timezone.timedelta(days=1),
-            notification_sent=False
+            notification_sent=False,
         )
 
     @patch("accounts.management.commands.notify_matches.send_mail")

--- a/game/context_processors.py
+++ b/game/context_processors.py
@@ -15,7 +15,7 @@ def game_session_processor(request):
                 is_active=True,  # Assuming you want only active game sessions
             ).latest(
                 "id"
-            )  # Assuming 'id' is an auto-incrementing field which reflects the creation order
+            )  # Assuming 'id' is an auto-incrementing that reflects creation order
 
             game_session_url = game_session.get_absolute_url()
             logger.info(

--- a/game/context_processors.py
+++ b/game/context_processors.py
@@ -1,0 +1,15 @@
+from game.models import GameSession
+
+def game_session_processor(request):
+    # Logic to get the most recent game session URL for the current user
+    if request.user.is_authenticated:
+        try:
+            # Assuming you have a method to get the latest game session for the user
+            game_session = GameSession.objects.filter(
+                playerA__user=request.user
+            ).latest('id')
+            return {'game_session_url': game_session.get_absolute_url()}
+        except GameSession.DoesNotExist:
+            # Handle the case where there is no game session
+            return {'game_session_url': None}
+    return {}

--- a/game/context_processors.py
+++ b/game/context_processors.py
@@ -1,19 +1,28 @@
 from game.models import GameSession
 import logging
+from django.db.models import Q
+
 
 logger = logging.getLogger(__name__)
 
 def game_session_processor(request):
     if request.user.is_authenticated:
         try:
+            # Filter GameSessions where the user is either playerA or playerB
             game_session = GameSession.objects.filter(
-                # Your conditions here
-            ).latest('id')
+                Q(playerA__user=request.user) | Q(playerB__user=request.user),
+                is_active=True  # Assuming you want only active game sessions
+            ).latest('id')  # Assuming 'id' is an auto-incrementing field which reflects the creation order
+
             game_session_url = game_session.get_absolute_url()
-            logger.info(f"Game session URL: {game_session_url}")
+            logger.info(f"Game session URL for user {request.user.username}: {game_session_url}")
             return {'game_session_url': game_session_url}
+
         except GameSession.DoesNotExist:
-            logger.info("No game session found")
+            logger.info(f"No game session found for user {request.user.username}")
             return {'game_session_url': None}
+
+    # Return an empty dictionary if the user is not authenticated
     return {}
+
 

--- a/game/context_processors.py
+++ b/game/context_processors.py
@@ -1,20 +1,6 @@
 from game.models import GameSession
-
-""" def game_session_processor(request):
-    # Logic to get the most recent game session URL for the current user
-    if request.user.is_authenticated:
-        try:
-            # Assuming you have a method to get the latest game session for the user
-            game_session = GameSession.objects.filter(
-                playerA__user=request.user
-            ).latest('id')
-            return {'game_session_url': game_session.get_absolute_url()}
-        except GameSession.DoesNotExist:
-            # Handle the case where there is no game session
-            return {'game_session_url': None}
-    return {} """
-
 import logging
+
 logger = logging.getLogger(__name__)
 
 def game_session_processor(request):

--- a/game/context_processors.py
+++ b/game/context_processors.py
@@ -5,24 +5,27 @@ from django.db.models import Q
 
 logger = logging.getLogger(__name__)
 
+
 def game_session_processor(request):
     if request.user.is_authenticated:
         try:
             # Filter GameSessions where the user is either playerA or playerB
             game_session = GameSession.objects.filter(
                 Q(playerA__user=request.user) | Q(playerB__user=request.user),
-                is_active=True  # Assuming you want only active game sessions
-            ).latest('id')  # Assuming 'id' is an auto-incrementing field which reflects the creation order
+                is_active=True,  # Assuming you want only active game sessions
+            ).latest(
+                "id"
+            )  # Assuming 'id' is an auto-incrementing field which reflects the creation order
 
             game_session_url = game_session.get_absolute_url()
-            logger.info(f"Game session URL for user {request.user.username}: {game_session_url}")
-            return {'game_session_url': game_session_url}
+            logger.info(
+                f"Game session URL for user {request.user.username}: {game_session_url}"
+            )
+            return {"game_session_url": game_session_url}
 
         except GameSession.DoesNotExist:
             logger.info(f"No game session found for user {request.user.username}")
-            return {'game_session_url': None}
+            return {"game_session_url": None}
 
     # Return an empty dictionary if the user is not authenticated
     return {}
-
-

--- a/game/context_processors.py
+++ b/game/context_processors.py
@@ -1,6 +1,6 @@
 from game.models import GameSession
 
-def game_session_processor(request):
+""" def game_session_processor(request):
     # Logic to get the most recent game session URL for the current user
     if request.user.is_authenticated:
         try:
@@ -12,4 +12,22 @@ def game_session_processor(request):
         except GameSession.DoesNotExist:
             # Handle the case where there is no game session
             return {'game_session_url': None}
+    return {} """
+
+import logging
+logger = logging.getLogger(__name__)
+
+def game_session_processor(request):
+    if request.user.is_authenticated:
+        try:
+            game_session = GameSession.objects.filter(
+                # Your conditions here
+            ).latest('id')
+            game_session_url = game_session.get_absolute_url()
+            logger.info(f"Game session URL: {game_session_url}")
+            return {'game_session_url': game_session_url}
+        except GameSession.DoesNotExist:
+            logger.info("No game session found")
+            return {'game_session_url': None}
     return {}
+

--- a/game/models.py
+++ b/game/models.py
@@ -146,8 +146,7 @@ class GameSession(models.Model):
         super(GameSession, self).save(*args, **kwargs)
 
     def get_absolute_url(self):
-        return reverse('game:game_progress', kwargs={'game_id': self.game_id})
-
+        return reverse("game:game_progress", kwargs={"game_id": self.game_id})
 
 
 class GameTurn(models.Model):

--- a/game/models.py
+++ b/game/models.py
@@ -2,6 +2,7 @@ from django.core.exceptions import ValidationError
 from django.db import models
 from django.contrib.auth.models import User
 import uuid
+from django.urls import reverse
 
 from django_fsm import FSMField, transition
 
@@ -143,6 +144,10 @@ class GameSession(models.Model):
             self.current_game_turn = GameTurn.objects.create()
         # Save the GameSession instance
         super(GameSession, self).save(*args, **kwargs)
+
+    def get_absolute_url(self):
+        return reverse('game:game_progress', kwargs={'game_id': self.game_id})
+
 
 
 class GameTurn(models.Model):

--- a/roleplaydate/settings.py
+++ b/roleplaydate/settings.py
@@ -67,6 +67,7 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
+                "game.context_processors.game_session_processor",
             ],
         },
     },
@@ -151,3 +152,5 @@ DEFAULT_FROM_EMAIL = "Roleplay then Date roleplayanddate@gmail.com"
 
 # SITE_URL = "http://roleplaydate-dev3.us-east-1.elasticbeanstalk.com"
 SITE_URL = "http://teamrepo-dev.us-east-1.elasticbeanstalk.com/"
+
+

--- a/roleplaydate/settings.py
+++ b/roleplaydate/settings.py
@@ -150,3 +150,20 @@ EMAIL_USE_TLS = True
 DEFAULT_FROM_EMAIL = "Roleplay then Date roleplayanddate@gmail.com"
 
 SITE_URL = "http://roleplaydate-dev3.us-east-1.elasticbeanstalk.com"
+
+# Delete
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+        },
+    },
+    'loggers': {
+        'django': {
+            'handlers': ['console'],
+            'level': 'DEBUG',
+        },
+    },
+}

--- a/roleplaydate/settings.py
+++ b/roleplaydate/settings.py
@@ -148,5 +148,3 @@ EMAIL_HOST_PASSWORD = os.environ.get("RPTHENDATE_EMAIL_HOST_PASSWORD")
 EMAIL_PORT = 587
 EMAIL_USE_TLS = True
 DEFAULT_FROM_EMAIL = "Roleplay then Date roleplayanddate@gmail.com"
-
-SITE_URL = "http://roleplaydate-dev3.us-east-1.elasticbeanstalk.com/"

--- a/roleplaydate/settings.py
+++ b/roleplaydate/settings.py
@@ -149,21 +149,5 @@ EMAIL_PORT = 587
 EMAIL_USE_TLS = True
 DEFAULT_FROM_EMAIL = "Roleplay then Date roleplayanddate@gmail.com"
 
-SITE_URL = "http://roleplaydate-dev3.us-east-1.elasticbeanstalk.com"
-
-# Delete
-LOGGING = {
-    'version': 1,
-    'disable_existing_loggers': False,
-    'handlers': {
-        'console': {
-            'class': 'logging.StreamHandler',
-        },
-    },
-    'loggers': {
-        'django': {
-            'handlers': ['console'],
-            'level': 'DEBUG',
-        },
-    },
-}
+# SITE_URL = "http://roleplaydate-dev3.us-east-1.elasticbeanstalk.com"
+SITE_URL = "http://teamrepo-dev.us-east-1.elasticbeanstalk.com/"

--- a/roleplaydate/settings.py
+++ b/roleplaydate/settings.py
@@ -150,5 +150,7 @@ EMAIL_PORT = 587
 EMAIL_USE_TLS = True
 DEFAULT_FROM_EMAIL = "Roleplay then Date roleplayanddate@gmail.com"
 
+# SITE_URL = "http://roleplaydate-dev3.us-east-1.elasticbeanstalk.com"
+SITE_URL = "http://teamrepo-dev.us-east-1.elasticbeanstalk.com/"
 
 

--- a/roleplaydate/settings.py
+++ b/roleplaydate/settings.py
@@ -148,3 +148,5 @@ EMAIL_HOST_PASSWORD = os.environ.get("RPTHENDATE_EMAIL_HOST_PASSWORD")
 EMAIL_PORT = 587
 EMAIL_USE_TLS = True
 DEFAULT_FROM_EMAIL = "Roleplay then Date roleplayanddate@gmail.com"
+
+SITE_URL = "http://roleplaydate-dev3.us-east-1.elasticbeanstalk.com/"

--- a/roleplaydate/settings.py
+++ b/roleplaydate/settings.py
@@ -150,7 +150,5 @@ EMAIL_PORT = 587
 EMAIL_USE_TLS = True
 DEFAULT_FROM_EMAIL = "Roleplay then Date roleplayanddate@gmail.com"
 
-# SITE_URL = "http://roleplaydate-dev3.us-east-1.elasticbeanstalk.com"
-SITE_URL = "http://teamrepo-dev.us-east-1.elasticbeanstalk.com/"
 
 

--- a/roleplaydate/settings.py
+++ b/roleplaydate/settings.py
@@ -149,4 +149,4 @@ EMAIL_PORT = 587
 EMAIL_USE_TLS = True
 DEFAULT_FROM_EMAIL = "Roleplay then Date roleplayanddate@gmail.com"
 
-SITE_URL = "http://roleplaydate-dev3.us-east-1.elasticbeanstalk.com/"
+SITE_URL = "http://roleplaydate-dev3.us-east-1.elasticbeanstalk.com"

--- a/roleplaydate/settings.py
+++ b/roleplaydate/settings.py
@@ -149,6 +149,3 @@ EMAIL_HOST_PASSWORD = os.environ.get("RPTHENDATE_EMAIL_HOST_PASSWORD")
 EMAIL_PORT = 587
 EMAIL_USE_TLS = True
 DEFAULT_FROM_EMAIL = "Roleplay then Date roleplayanddate@gmail.com"
-
-
-

--- a/roleplaydate/urls.py
+++ b/roleplaydate/urls.py
@@ -44,7 +44,7 @@ urlpatterns = [
     path("api/reset-likes/", reset_likes),
     path("tags/", include("tags.urls")),
     path("api/notify-matches/", notify_matches),
-    path("game/", include(("game.urls", 'game'), namespace='game')),
+    path("game/", include(("game.urls", "game"), namespace="game")),
 ]
 
 # Add the following line to serve media files during development

--- a/roleplaydate/urls.py
+++ b/roleplaydate/urls.py
@@ -44,6 +44,7 @@ urlpatterns = [
     path("api/reset-likes/", reset_likes),
     path("tags/", include("tags.urls")),
     path("api/notify-matches/", notify_matches),
+    path("game/", include(("game.urls", 'game'), namespace='game')),
 ]
 
 # Add the following line to serve media files during development

--- a/templates/base.html
+++ b/templates/base.html
@@ -13,7 +13,7 @@
         .inactive-link {
             color: #c0c0c0; /* Grey color for inactive link */
             pointer-events: none; /* Make the link non-clickable */
-            cursor: default; /* Change cursor style */
+            cursor: not-allowed; 
             text-decoration: none; /* Optional: Remove underline from the link */
         }
 
@@ -52,6 +52,16 @@
             font-weight: bold ;
         }
         .sidebar a:hover {
+            background-color: #f0d9f0ff;
+            color: #ffffff;
+        }
+        .sidebar a.inactive-link {
+        color: #c0c0c0; /* Grey color for inactive link */
+        pointer-events: none; /* Make the link non-clickable */
+        cursor: not-allowed; 
+        text-decoration: none; /* Optional: Remove underline from the link */
+        }
+        .sidebar a:hover:not(.inactive-link) {
             background-color: #f0d9f0ff;
             color: #ffffff;
         }
@@ -108,9 +118,7 @@
             <a href="{% url 'browse_profiles' %}">Browse Profile</a>
             <!-- Conditional class assignment for Playground link -->
             <a href="{% if game_session_url %}{{ game_session_url }}{% else %}#{% endif %}" 
-               class="{% if not game_session_url %}inactive-link{% endif %}">
-                Playground
-            </a>
+                class="sidebar a {% if not game_session_url %}inactive-link{% endif %}">Playground</a>
             <a href="{% url 'tag_view' %}">Tags</a>
             <a href="{% url 'account' %}">Account</a>
             <a href="#">Settings</a>

--- a/templates/base.html
+++ b/templates/base.html
@@ -10,6 +10,12 @@
     <link rel="stylesheet" href="{% static 'css/styles.css' %}" />
     <style>
 
+        .inactive-link {
+            color: #c0c0c0; /* or any color you wish to represent as 'disabled' */
+            pointer-events: none; /* This will make the link non-clickable */
+            cursor: default;
+        }
+
         .navbar {
             background-color: #0E6655;
             border-bottom: 3px solid #196F3D;
@@ -99,8 +105,9 @@
         <div class="col-md-3 sidebar">
             <a href="{% url 'view_profile' %}">View Profile</a>
             <a href="{% url 'browse_profiles' %}">Browse Profile</a>
-            <a href="{% if game_session_url %}{{ game_session_url }}{% else %}#{% endif %}">Playground</a>
-            <!-- is this correct? -->
+            <!-- Add a conditional class to the Playground link based on game_session_url -->
+            <a href="{% if game_session_url %}{{ game_session_url }}{% else %}#{% endif %}" 
+               class="{% if not game_session_url %}inactive-link{% endif %}">Playground</a>
             <a href="{% url 'tag_view' %}">Tags</a>
             <a href="{% url 'account' %}">Account</a>
             <a href="#">Settings</a>

--- a/templates/base.html
+++ b/templates/base.html
@@ -99,7 +99,7 @@
         <div class="col-md-3 sidebar">
             <a href="{% url 'view_profile' %}">View Profile</a>
             <a href="{% url 'browse_profiles' %}">Browse Profile</a>
-            <a href="#">Playground</a>
+            <a href="{% if game_session_url %}{{ game_session_url }}{% else %}#{% endif %}">Playground</a>
             <!-- is this correct? -->
             <a href="{% url 'tag_view' %}">Tags</a>
             <a href="{% url 'account' %}">Account</a>

--- a/templates/base.html
+++ b/templates/base.html
@@ -11,9 +11,10 @@
     <style>
 
         .inactive-link {
-            color: #c0c0c0; /* or any color you wish to represent as 'disabled' */
-            pointer-events: none; /* This will make the link non-clickable */
-            cursor: default;
+            color: #c0c0c0; /* Grey color for inactive link */
+            pointer-events: none; /* Make the link non-clickable */
+            cursor: default; /* Change cursor style */
+            text-decoration: none; /* Optional: Remove underline from the link */
         }
 
         .navbar {
@@ -105,9 +106,11 @@
         <div class="col-md-3 sidebar">
             <a href="{% url 'view_profile' %}">View Profile</a>
             <a href="{% url 'browse_profiles' %}">Browse Profile</a>
-            <!-- Add a conditional class to the Playground link based on game_session_url -->
+            <!-- Conditional class assignment for Playground link -->
             <a href="{% if game_session_url %}{{ game_session_url }}{% else %}#{% endif %}" 
-               class="{% if not game_session_url %}inactive-link{% endif %}">Playground</a>
+               class="{% if not game_session_url %}inactive-link{% endif %}">
+                Playground
+            </a>
             <a href="{% url 'tag_view' %}">Tags</a>
             <a href="{% url 'account' %}">Account</a>
             <a href="#">Settings</a>

--- a/templates/base.html
+++ b/templates/base.html
@@ -118,7 +118,7 @@
             <a href="{% url 'browse_profiles' %}">Browse Profile</a>
             <!-- Conditional class assignment for Playground link -->
             <a href="{% if game_session_url %}{{ game_session_url }}{% else %}#{% endif %}" 
-                class="sidebar a {% if not game_session_url %}inactive-link{% endif %}">Playground</a>
+                class="{% if not game_session_url %}inactive-link{% endif %}">Playground</a>
             <a href="{% url 'tag_view' %}">Tags</a>
             <a href="{% url 'account' %}">Account</a>
             <a href="#">Settings</a>


### PR DESCRIPTION
I made a series of changes and updates to the app:

1. The **notify_matches** command has been updated to create a new game session between users who match at midnight, in addition to sending an email notification.
2. The email no longer includes a direct link to the game session. This change is due to the complexity of managing domain variations across different environments. Instead, users can navigate to the 'Playground' link within the app.
<img width="976" alt="Screenshot 2023-11-09 at 10 06 37 AM" src="https://github.com/gcivil-nyu-org/INET-Monday-Fall2023-Team-5/assets/90568586/975cb25b-8197-4d86-b5f6-321a1af848c8">
3.  The 'Playground' link on the user interface will appear grayed out if there is no active game session, indicating it's inactive. If a game session is active, the link will appear normally, indicating users can click on it to participate in the game.<img width="1309" alt="inactiveLink" src="https://github.com/gcivil-nyu-org/INET-Monday-Fall2023-Team-5/assets/90568586/e697dbee-10ab-4dfe-8a6c-44fb71e14e77">
4.  Details of the updated NotifyMatchesCommandTest are provided. The test setup now includes creating game sessions, game turns, and player instances. The test checks both for the sending of notifications and the handling of exceptions when sending emails.

The process for initiating a game between two users is outlined in steps:

1. Two users like each other, creating a match.
2. An admin confirms the match in the Match Table.
3. The admin triggers the notify_matches command via a URL, which should be accessed while logged in as an admin:  domain/api/notify-matches
<img width="1076" alt="Screenshot 2023-11-09 at 10 26 47 AM" src="https://github.com/gcivil-nyu-org/INET-Monday-Fall2023-Team-5/assets/90568586/9763a750-19a5-42a9-b09e-caa6eba6b74c">

5.  This action changes the 'notification sent' status in the Match table and sends an email to the matched users.
<img width="685" alt="Screenshot 2023-11-09 at 10 26 57 AM" src="https://github.com/gcivil-nyu-org/INET-Monday-Fall2023-Team-5/assets/90568586/081d0e72-9779-4020-a397-5ae4889ca986">

6.  A game session is also automatically initiated between the matched users. They can then go to the 'Playground' link to start playing.
7. The admin has the option to reset likes by navigating to the folllwing URL: domain/api/reset-likes
