### PR TITLE
Temporary Removal of Staff Restrictions for Test Command Accessibility

### DIFF
--- a/roleplaydate/urls.py
+++ b/roleplaydate/urls.py
@@ -21,16 +21,17 @@ from django.conf import settings  # Import settings
 from django.conf.urls.static import static  # Import static
 from django.http import HttpResponse
 from django.core.management import call_command
+
 # from django.contrib.admin.views.decorators import staff_member_required
 
 
-# @staff_member_required 
+# @staff_member_required
 def notify_matches(request):
     call_command("notify_matches")
     return HttpResponse("Match notifications have been sent.")
 
 
-# @staff_member_required 
+# @staff_member_required
 def reset_likes(request):
     call_command("reset_likes")
     return HttpResponse("Likes have been reset.")

--- a/roleplaydate/urls.py
+++ b/roleplaydate/urls.py
@@ -24,13 +24,13 @@ from django.core.management import call_command
 from django.contrib.admin.views.decorators import staff_member_required
 
 
-# @staff_member_required
+# @staff_member_required # noqa: E501
 def notify_matches(request):
     call_command("notify_matches")
     return HttpResponse("Match notifications have been sent.")
 
 
-# @staff_member_required
+# @staff_member_required # noqa: E501
 def reset_likes(request):
     call_command("reset_likes")
     return HttpResponse("Likes have been reset.")

--- a/roleplaydate/urls.py
+++ b/roleplaydate/urls.py
@@ -21,16 +21,16 @@ from django.conf import settings  # Import settings
 from django.conf.urls.static import static  # Import static
 from django.http import HttpResponse
 from django.core.management import call_command
-from django.contrib.admin.views.decorators import staff_member_required
+# from django.contrib.admin.views.decorators import staff_member_required
 
 
-# @staff_member_required # noqa: F401
+# @staff_member_required 
 def notify_matches(request):
     call_command("notify_matches")
     return HttpResponse("Match notifications have been sent.")
 
 
-# @staff_member_required # noqa: F401
+# @staff_member_required 
 def reset_likes(request):
     call_command("reset_likes")
     return HttpResponse("Likes have been reset.")

--- a/roleplaydate/urls.py
+++ b/roleplaydate/urls.py
@@ -24,13 +24,13 @@ from django.core.management import call_command
 from django.contrib.admin.views.decorators import staff_member_required
 
 
-@staff_member_required
+# @staff_member_required
 def notify_matches(request):
     call_command("notify_matches")
     return HttpResponse("Match notifications have been sent.")
 
 
-@staff_member_required
+# @staff_member_required
 def reset_likes(request):
     call_command("reset_likes")
     return HttpResponse("Likes have been reset.")

--- a/roleplaydate/urls.py
+++ b/roleplaydate/urls.py
@@ -24,13 +24,13 @@ from django.core.management import call_command
 from django.contrib.admin.views.decorators import staff_member_required
 
 
-# @staff_member_required # noqa: E501
+# @staff_member_required # noqa: F401
 def notify_matches(request):
     call_command("notify_matches")
     return HttpResponse("Match notifications have been sent.")
 
 
-# @staff_member_required # noqa: E501
+# @staff_member_required # noqa: F401
 def reset_likes(request):
     call_command("reset_likes")
     return HttpResponse("Likes have been reset.")


### PR DESCRIPTION
To facilitate efficient testing, the @staff_member_required decorator has been temporarily disabled. This modification allows users to manually activate the reset_likes and notify_matches commands at any time, eliminating the need to wait until midnight.

<img width="703" alt="Screenshot 2023-11-13 at 4 46 22 PM" src="https://github.com/gcivil-nyu-org/INET-Monday-Fall2023-Team-5/assets/90568586/da2785e4-0acf-4e75-b166-5bbc4aeb35de">
